### PR TITLE
Fix microphone release after recording

### DIFF
--- a/src/components/AudioRecorder.jsx
+++ b/src/components/AudioRecorder.jsx
@@ -30,7 +30,12 @@ export default function AudioRecorder({ onTranscribe }) {
   };
 
   const stopRecording = () => {
-    mediaRecorder.current?.stop();
+    if (mediaRecorder.current) {
+      mediaRecorder.current.stop();
+      mediaRecorder.current.stream
+        .getTracks()
+        .forEach(track => track.stop());
+    }
     setRecording(false);
   };
 


### PR DESCRIPTION
## Summary
- ensure `MediaRecorder`'s stream tracks are stopped when recording stops

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862e40535288331b435b17b7f2fe6ed