### PR TITLE
Improve README and add transcribe endpoint example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL de la API utilizada por la aplicación
+VITE_API_BASE_URL=https://noteupapp.vercel.app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+.env
+
+# Logs
+npm-debug.log*
+.yarn-debug.log*
+.yarn-error.log*
+
+# Build output
+/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Noteup
+# NoteUp
+
+NoteUp es una aplicación web progresiva (PWA) que permite grabar audio desde el navegador y obtener una transcripción, traducción y resumen del mismo.
+
+## Desarrollo
+
+1. Instala las dependencias
+   ```bash
+   npm install
+   ```
+2. Crea un archivo `.env` basado en `.env.example` y define la URL de la API:
+   ```bash
+   VITE_API_BASE_URL=https://noteupapp.vercel.app
+   ```
+3. Inicia el servidor de desarrollo
+   ```bash
+   npm run dev
+   ```
+
+## Variables de entorno
+
+- `VITE_API_BASE_URL` – Dirección base del backend que provee los endpoints `/api/transcribe`, `/api/translate` y `/api/summarize`.
+
+## Construcción y despliegue
+
+Ejecuta `npm run build` para generar los archivos estáticos. Asegúrate de que `VITE_API_BASE_URL` esté configurada en el entorno de producción.

--- a/api/transcribe.js
+++ b/api/transcribe.js
@@ -1,0 +1,61 @@
+import formidable from 'formidable';
+import fs from 'fs';
+import FormData from 'form-data';
+import fetch from 'node-fetch';
+
+export const config = {
+  api: {
+    bodyParser: false
+  }
+};
+
+export default async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.status(200).end();
+    return;
+  }
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Método no permitido' });
+    return;
+  }
+
+  const form = new formidable.IncomingForm();
+
+  form.parse(req, async (err, fields, files) => {
+    if (err) {
+      res.status(500).json({ error: 'Error al procesar archivo', detail: err.message });
+      return;
+    }
+
+    const file = files.audio;
+    if (!file) {
+      res.status(400).json({ error: 'Archivo de audio no proporcionado.' });
+      return;
+    }
+
+    const fileStream = fs.createReadStream(file.filepath);
+    const formData = new FormData();
+    formData.append('file', fileStream, file.originalFilename);
+    // campos adicionales para el servicio de transcripción
+    if (fields.language) formData.append('language', fields.language);
+
+    try {
+      const response = await fetch(process.env.TRANSCRIBE_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.TRANSCRIBE_API_KEY}`,
+          ...formData.getHeaders()
+        },
+        body: formData
+      });
+      const data = await response.json();
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.status(response.ok ? 200 : 500).json(data);
+    } catch (e) {
+      res.status(500).json({ error: 'Error al comunicarse con el servicio', detail: e.message });
+    }
+  });
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>NoteUp</title>
   </head>
   <body>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "NoteUp",
+  "short_name": "NoteUp",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#003569",
+  "theme_color": "#003569",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.2",
-    "react-icons": "^4.12.0"
+    "react-icons": "^4.12.0",
+    "formidable": "^3.5.0",
+    "form-data": "^4.0.0",
+    "node-fetch": "^2.6.7"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/components/AudioRecorder.jsx
+++ b/src/components/AudioRecorder.jsx
@@ -44,7 +44,8 @@ export default function AudioRecorder({ onTranscribe }) {
       const formData = new FormData();
       formData.append("audio", audioBlob, "grabacion.webm");
 
-      const res = await fetch("https://noteupapp.vercel.app/api/transcribe", {
+      const base = import.meta.env.VITE_API_BASE_URL || "";
+      const res = await fetch(`${base}/api/transcribe`, {
         method: "POST",
         body: formData
       });

--- a/src/components/Summarizer.jsx
+++ b/src/components/Summarizer.jsx
@@ -8,7 +8,8 @@ export default function Summarizer({ text }) {
   const summarize = async () => {
     setLoading(true); setError(""); setSummary("");
     try {
-      const res = await fetch("https://noteupapp.vercel.app/api/summarize", {
+      const base = import.meta.env.VITE_API_BASE_URL || "";
+      const res = await fetch(`${base}/api/summarize`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text })

--- a/src/components/Translator.jsx
+++ b/src/components/Translator.jsx
@@ -13,7 +13,8 @@ export default function Translator({ text }) {
   const translate = async () => {
     setLoading(true); setError(""); setTranslated("");
     try {
-      const res = await fetch("https://noteupapp.vercel.app/api/translate", {
+      const base = import.meta.env.VITE_API_BASE_URL || "";
+      const res = await fetch(`${base}/api/translate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text, targetLanguage })


### PR DESCRIPTION
## Summary
- replace corrupted README with project info
- add minimal PWA manifest and link it in `index.html`
- allow configuration of API base URL via `VITE_API_BASE_URL`
- add sample `api/transcribe` function with CORS support
- provide `.env.example` and `.gitignore`
- update dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e7ea576883319b892c0700a44e60