### PR TITLE
Add CORS headers to all responses

### DIFF
--- a/api/transcribe.js
+++ b/api/transcribe.js
@@ -10,6 +10,9 @@ export const config = {
 };
 
 export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   if (req.method === 'OPTIONS') {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
@@ -18,6 +21,9 @@ export default async function handler(req, res) {
     return;
   }
   if (req.method !== 'POST') {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
     res.status(405).json({ error: 'Método no permitido' });
     return;
   }
@@ -26,12 +32,18 @@ export default async function handler(req, res) {
 
   form.parse(req, async (err, fields, files) => {
     if (err) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
       res.status(500).json({ error: 'Error al procesar archivo', detail: err.message });
       return;
     }
 
     const file = files.audio;
     if (!file) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
       res.status(400).json({ error: 'Archivo de audio no proporcionado.' });
       return;
     }
@@ -53,8 +65,13 @@ export default async function handler(req, res) {
       });
       const data = await response.json();
       res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
       res.status(response.ok ? 200 : 500).json(data);
     } catch (e) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
       res.status(500).json({ error: 'Error al comunicarse con el servicio', detail: e.message });
     }
   });


### PR DESCRIPTION
## Summary
- set `Access-Control-Allow-*` headers at the start of the transcribe handler
- apply the same headers on every code path, including errors and fetch results

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862fb16f4ac8331bf3d8fed26efe83c